### PR TITLE
cs - Added reset schedule button

### DIFF
--- a/components/ClearSchedule.js
+++ b/components/ClearSchedule.js
@@ -1,0 +1,35 @@
+import useSWR from "swr";
+import { useCallback } from "react";
+import { useToasts } from "./Toasts";
+import { Form } from "react-bootstrap";
+import Button from "react-bootstrap/Button";
+
+export default function clearSchedule() {
+  const { showToast } = useToasts();
+  const { data, mutate } = useSWR("/api/event");
+
+  const deleteId = useCallback(async (eventId) => {
+    showToast(`Cleared schedule!`);
+    await fetch(`/api/event/${eventId}`, { method: "DELETE" });
+    await mutate();
+  }, []);
+
+  function resetSchedule() {
+    var reset = confirm("Are you sure you want to reset your schedule?");
+    if (reset == true) {
+      if (typeof data === "object") {
+        for (let i = 0; i < data.length; i++) {
+          deleteId(data[i]._id);
+        }
+      }
+    }
+  }
+
+  return (
+    <Form.Group>
+      <Button variant="danger" onClick={() => resetSchedule()}>
+        Reset Schedule
+      </Button>
+    </Form.Group>
+  );
+}

--- a/pages/my-schedule/index.js
+++ b/pages/my-schedule/index.js
@@ -4,6 +4,7 @@ import NewEventForm from "../../components/NewEventForm";
 import ScheduleTable from "../../components/ScheduleTable";
 import useSWR from "swr";
 import FreeTime from "../../components/FreeTime";
+import ClearSchedule from "../../components/ClearSchedule";
 
 export const getServerSideProps = requiredAuth;
 
@@ -17,6 +18,7 @@ function SchedulePage(props) {
       <NewEventForm />
       <ScheduleTable />
       <FreeTime />
+      <ClearSchedule />
     </Layout>
   );
 }


### PR DESCRIPTION
Added a reset schedule button at the bottom of My Schedule page. The reset schedule button clears all of a user's events and removes those events from MongoDB. Upon clicking the button, a confirmation message pops up to confirm if the user really wants to reset their schedule or not.