### PR TITLE
cs - add leave all groups button

### DIFF
--- a/components/GroupsTable.js
+++ b/components/GroupsTable.js
@@ -16,6 +16,18 @@ function createTable(data, membersJSON) {
     mutate();
   });
 
+  function resetGroups() {
+    var reset = confirm("Are you sure you want to leave all groups?");
+    if (reset == true) {
+      if (typeof data === "object" && typeof membersJSON === "object") {
+        for (let i = 0; i < data.length; i++) {
+          leaveGroup(data[i].code, data[i].name);
+        }
+      }
+      showToast("Left all groups!");
+    }
+  }
+
   if (typeof data === "object" && typeof membersJSON === "object") {
     const items = [];
 
@@ -49,6 +61,26 @@ function createTable(data, membersJSON) {
                 Leave
               </Button>
             )}
+          </td>
+        </tr>
+      );
+    }
+
+    if (isLeaveMode) {
+      items.push(
+        <tr style={{ backgroundColor: "#ffbfc2" }}>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td>
+            {
+              <Form.Group>
+                <Button variant="danger" onClick={() => resetGroups()}>
+                  Leave All
+                </Button>
+              </Form.Group>
+            }
           </td>
         </tr>
       );


### PR DESCRIPTION
Added a "Leave All" button at the bottom most row of the Groups Table that only appears when the "Leave" switch is checked. A confirmation text appears to make sure the user wants to leave all groups. If the user selects "OK", they are removed from all of their Groups.